### PR TITLE
add "set -s escape-time 0" for getting rid of ESC delay in tmux terminal when needed.

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,5 +1,5 @@
 # Created:  Fang lungang 2010-11-08
-# Modified: Lungang Fang 2023-03-23T00:40:18+1100>
+# Modified: My name 11/14/2023 15:09>
 
 #* color theme
 source-file ~/.tmux.d/lgfang-concise
@@ -32,6 +32,12 @@ set-option -g default-terminal "xterm-256color"
 #* Terminal emulator window title
 set-option -g set-titles on
 set-option -g set-titles-string 'tmux:#S@#h'
+
+#* Server Options
+## NOTE: Comment out this if you don't use ESC as Meta key and want a immediate ESC response
+## If ESC used as Meta key, when hitting ESC, a small delay happens in terminal.
+## it is defalut 1000ms for tmux server.
+# set -s escape-time 0
 
 #* Mouse support
 set-option -g mouse on


### PR DESCRIPTION
Hi Ark,

I added "excape-time" into tmux.conf. I have a python script using ESC key, need it response realtime. After changing "ESCDELAY" and using set_escdelay() , i found rc is tmux handling ESC. So I added "set -s escape-time 0" into .tmux.conf in case someone want to eliminate ESC delay in tmux terminal.

-Stanley